### PR TITLE
To preserve colors use {stdio:'inherit'} in spawn() instead of binding on stdout and stderr

### DIFF
--- a/tasks/titanium.js
+++ b/tasks/titanium.js
@@ -214,13 +214,7 @@ module.exports = function(grunt) {
 
 		// spawn command and output
 		grunt.log.writeln('titanium ' + args.join(' '));
-		var ti = spawn(getTitaniumPath(), args);
-		ti.stdout.on('data', function(data) {
-			process.stdout.write(data);
-		});
-		ti.stderr.on('data', function(data) {
-			process.stdout.write(data);
-		});
+		var ti = spawn(getTitaniumPath(), args, {stdio: 'inherit'});
 		ti.on('close', function(code) {
 			if (command !== 'build' || options.buildOnly) {
 				grunt.log[code ? 'error' : 'ok']('titanium ' + command + ' ' + (code ? 'failed' : 'complete') + '.');


### PR DESCRIPTION
When listening to stderr and stdout, colors are not preserved.

Spawning the child process with option property: { stdio: "inherit" } instead, does preserve them.
